### PR TITLE
adjust-field-relative-binding

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -75,7 +75,7 @@ public class RobotContainer {
 				.oddSquare(MathUtil.applyDeadband(-m_driveController.getRightX(),
 						OIConstants.kControllerDeadband))
 				* SwerveConstants.kMaxAngularSpeedRadiansPerSecond;
-		BooleanSupplier fieldRelative = () -> m_driveController.getRightBumper();
+		BooleanSupplier fieldRelative = () -> !m_driveController.getRightBumper();
 		m_defaultMoveCommand = new MoveCommand(m_swerveDriveSubsystem)
 				.withXSpeedSupplier(x)
 				.withYSpeedSupplier(y)


### PR DESCRIPTION
Swapped action of the drivers right bumper to make field relative driving the default method. Meant to make driving easier for off-season comps so new drivers can get more used to field relative driving without having to uselessly hold down the bumper.